### PR TITLE
feat!: Generate API Config url dynamically based on a group of enviro…

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,9 @@ let config = {
   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
   LOGO_WHITE_URL: process.env.LOGO_WHITE_URL,
   FAVICON_URL: process.env.FAVICON_URL,
-  MFE_CONFIG_API_URL: process.env.MFE_CONFIG_API_URL,
+  MFE_CONFIG_API_PATH: process.env.MFE_CONFIG_API_PATH,
+  MFE_CONFIG_API_PORT: process.env.MFE_CONFIG_API_PORT,
+  MFE_CONFIG_API_REGEX: process.env.MFE_CONFIG_API_REGEX,
   APP_ID: process.env.APP_ID,
 };
 
@@ -195,6 +197,8 @@ export function ensureConfig(keys, requester = 'unspecified application code') {
  * @property {string} LOGO_TRADEMARK_URL
  * @property {string} LOGO_WHITE_URL
  * @property {string} FAVICON_URL
- * @property {string} MFE_CONFIG_API_URL
+ * @property {string} MFE_CONFIG_API_PATH
+ * @property {string} MFE_CONFIG_API_PORT
+ * @property {string} MFE_CONFIG_API_REGEX
  * @property {string} APP_ID
  */

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {
   convertKeyNames,
   getQueryParameters,
   ensureDefinedConfig,
+  generateAPIConfigUrl,
 } from './utils';
 export {
   APP_TOPIC,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -79,6 +79,7 @@ import {
   APP_READY, APP_INIT_ERROR,
 } from './constants';
 import configureCache from './auth/LocalForageCache';
+import { generateAPIConfigUrl } from './utils';
 
 /**
  * A browser history or memory history object created by the [history](https://github.com/ReactTraining/history)
@@ -138,16 +139,11 @@ export async function auth(requireUser, hydrateUser) {
 
 export async function runtimeConfig() {
   try {
-    const { MFE_CONFIG_API_URL, APP_ID } = getConfig();
+    const url = generateAPIConfigUrl();
 
-    if (MFE_CONFIG_API_URL) {
+    if (url) {
       const apiConfig = { headers: { accept: 'application/json' } };
       const apiService = await configureCache();
-
-      const params = new URLSearchParams();
-      params.append('mfe', APP_ID);
-      const url = `${MFE_CONFIG_API_URL}?${params.toString()}`;
-
       const { data } = await apiService.get(url, apiConfig);
       mergeConfig(data);
     }

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -31,12 +31,14 @@ import { configure as configureAnalytics, SegmentAnalyticsService } from './anal
 import { configure as configureI18n } from './i18n';
 import { getConfig } from './config';
 import configureCache from './auth/LocalForageCache';
+import { generateAPIConfigUrl } from './utils';
 
 jest.mock('./logging');
 jest.mock('./auth');
 jest.mock('./analytics');
 jest.mock('./i18n');
 jest.mock('./auth/LocalForageCache');
+jest.mock('./utils');
 
 let config = null;
 const newConfig = {
@@ -279,8 +281,7 @@ describe('initialize', () => {
   });
 
   it('should initialize the app with runtime configuration', async () => {
-    config.MFE_CONFIG_API_URL = 'http://localhost:18000/api/mfe/v1/config';
-    config.APP_ID = 'auth';
+    generateAPIConfigUrl.mockReturnValueOnce('http://localhost:18000/api/mfe/v1/config?mfe=auth');
     configureCache.mockReturnValueOnce(Promise.resolve({
       get: (url) => {
         const params = new URL(url).search;
@@ -319,8 +320,7 @@ describe('initialize', () => {
   });
 
   it('should initialize the app with the build config when runtime configuration fails', async () => {
-    config.MFE_CONFIG_API_URL = 'http://localhost:18000/api/mfe/v1/config';
-    // eslint-disable-next-line no-console
+    generateAPIConfigUrl.mockReturnValueOnce('http://localhost:18000/api/mfe/v1/config?mfe=auth');
     console.error = jest.fn();
     configureCache.mockReturnValueOnce(Promise.reject(new Error('Api fails')));
 


### PR DESCRIPTION
**Description:**
Make MFEs multitenant, these modifications allow to generate dynamically the config API url domain based on the current domain, this logic is based on the assumption that all MFEs  must be hosted in the lms sub-domain in order to allow the cookies authentication, therefore the config API url could be a combination of the current domain and this value could be extracted by using a regex

